### PR TITLE
Fix typo: ro -> to

### DIFF
--- a/example-adapter.js
+++ b/example-adapter.js
@@ -126,7 +126,7 @@ class ExampleAdapter extends Adapter {
   }
 
   /**
-   * Example process ro remove a device from the adapter.
+   * Example process to remove a device from the adapter.
    *
    * The important part is to call: `this.handleDeviceRemoved(device)`
    *


### PR DESCRIPTION
I assume this is supposed to say "to".